### PR TITLE
Enable auto refresh and optional due time

### DIFF
--- a/lib/pages/dashboard/dashboard_page.dart
+++ b/lib/pages/dashboard/dashboard_page.dart
@@ -259,13 +259,14 @@ class _DashboardPageState extends State<DashboardPage> {
   return Column(
       children: quests.map((quest) {
         return InkWell(
-          onTap: () {
-            Navigator.push(
+          onTap: () async {
+            final deleted = await Navigator.push(
               context,
               MaterialPageRoute(
                 builder: (_) => QuestDetailsPage(quest: quest),
               ),
             );
+            if (deleted == true) setState(() {});
           },
           child: Card(
             elevation: 2.0,
@@ -281,7 +282,7 @@ class _DashboardPageState extends State<DashboardPage> {
                           TextStyle(color: _isOverdue(quest) ? Colors.red : null),
                     )
                   : Text(
-                      'Scadenza: ${DateFormat('dd/MM/yyyy').format(quest.deadline)}',
+                      "Scadenza: ${DateFormat('dd/MM/yyyy').format(quest.deadline)}${quest.deadline.hour != 0 || quest.deadline.minute != 0 ? ' ${DateFormat('HH:mm').format(quest.deadline)}' : ''}",
                       style:
                           TextStyle(color: _isOverdue(quest) ? Colors.red : null),
                     ),

--- a/lib/pages/quests/new_quest_page.dart
+++ b/lib/pages/quests/new_quest_page.dart
@@ -33,6 +33,7 @@ class _NewQuestPageState extends State<NewQuestPage> {
   DateTime? repeatUntil;
 
   DateTime? selectedDeadline;
+  TimeOfDay? selectedDeadlineTime;
 
   int fatigue = 0;
 
@@ -192,6 +193,29 @@ class _NewQuestPageState extends State<NewQuestPage> {
                   ),
                 ],
               ),
+              const SizedBox(height: 8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text('Ora (opzionale)'),
+                  TextButton(
+                    onPressed: () async {
+                      final picked = await showTimePicker(
+                        context: context,
+                        initialTime: selectedDeadlineTime ?? TimeOfDay.now(),
+                      );
+                      if (picked != null) {
+                        setState(() => selectedDeadlineTime = picked);
+                      }
+                    },
+                    child: Text(
+                      selectedDeadlineTime == null
+                          ? 'Scegli ora'
+                          : selectedDeadlineTime!.format(context),
+                    ),
+                  ),
+                ],
+              ),
               const SizedBox(height: 16),
             ],
             const SizedBox(height: 20),
@@ -239,9 +263,16 @@ class _NewQuestPageState extends State<NewQuestPage> {
         }
       }
     } else {
-      final d = selectedDeadline != null
+      final baseDate = selectedDeadline != null
           ? DateTime(selectedDeadline!.year, selectedDeadline!.month, selectedDeadline!.day)
           : DateTime.now();
+      final d = DateTime(
+        baseDate.year,
+        baseDate.month,
+        baseDate.day,
+        selectedDeadlineTime?.hour ?? 0,
+        selectedDeadlineTime?.minute ?? 0,
+      );
       final q = QuestData(
         title: newTitle,
         deadline: d,

--- a/lib/pages/quests/quest_detail_page.dart
+++ b/lib/pages/quests/quest_detail_page.dart
@@ -18,7 +18,7 @@ class QuestDetailsPage extends StatelessWidget {
             onPressed: () async {
               // elimina e torna indietro
               await QuestService().removeQuest(quest);
-              Navigator.of(context).pop();
+              Navigator.of(context).pop(true);
             },
           ),
           IconButton(
@@ -36,7 +36,9 @@ class QuestDetailsPage extends StatelessWidget {
           children: [
             Text('Titolo: ${quest.title}', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
-            Text('Scadenza: ${DateFormat('dd/MM/yyyy').format(quest.deadline)}'),
+            Text(
+              "Scadenza: ${DateFormat('dd/MM/yyyy').format(quest.deadline)}${quest.deadline.hour != 0 || quest.deadline.minute != 0 ? ' ${DateFormat('HH:mm').format(quest.deadline)}' : ''}",
+            ),
             const SizedBox(height: 8),
             Text('XP: ${quest.xp}'),
             const SizedBox(height: 8),

--- a/lib/pages/quests/quests_page.dart
+++ b/lib/pages/quests/quests_page.dart
@@ -84,11 +84,20 @@ class _QuestsPageState extends State<QuestsPage> {
                       style:
                           TextStyle(color: _isOverdue(quest) ? Colors.red : null))
                   : Text(
-                      'Scadenza: ${DateFormat('dd/MM/yyyy').format(quest.deadline)}',
+                      "Scadenza: ${DateFormat('dd/MM/yyyy').format(quest.deadline)}${quest.deadline.hour != 0 || quest.deadline.minute != 0 ? ' ${DateFormat('HH:mm').format(quest.deadline)}' : ''}",
                       style:
                           TextStyle(color: _isOverdue(quest) ? Colors.red : null),
                     ),
               trailing: const Icon(Icons.arrow_forward_ios),
+              onTap: () async {
+                final deleted = await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => QuestDetailsPage(quest: quest),
+                  ),
+                );
+                if (deleted == true) setState(() {});
+              },
             ),
           );
         },
@@ -299,18 +308,19 @@ class _QuestsPageState extends State<QuestsPage> {
                       subtitle: Text(
                         quest.isDaily
                             ? 'Quest Giornaliera'
-                            : 'Scadenza: ${DateFormat('dd/MM/yyyy').format(quest.deadline)}',
+                            : "Scadenza: ${DateFormat('dd/MM/yyyy').format(quest.deadline)}${quest.deadline.hour != 0 || quest.deadline.minute != 0 ? ' ${DateFormat('HH:mm').format(quest.deadline)}' : ''}",
                         style:
                             TextStyle(color: _isOverdue(quest) ? Colors.red : null),
                       ),
                       trailing: const Icon(Icons.arrow_forward_ios),
-                      onTap: () {
-                        Navigator.push(
+                      onTap: () async {
+                        final deleted = await Navigator.push(
                           context,
                           MaterialPageRoute(
                             builder: (_) => QuestDetailsPage(quest: quest),
                           ),
                         );
+                        if (deleted == true) setState(() {});
                       },
                     ),
                   );


### PR DESCRIPTION
## Summary
- refresh pages after deleting quests
- allow setting an optional due time when creating quests
- show the due hour on detail, list and dashboard screens

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b9856dac0832cabcd7af8c2816e7f