### PR TITLE
Add theme settings page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,40 +1,50 @@
 import 'package:flutter/material.dart';
-// import 'package:tuo_progetto/theme/solo_leveling_theme.dart';
-// import 'package:life_leveling/routes/app_routes.dart';
-// import 'package:tuo_progetto/pages/settings/settings_page.dart';
 import 'package:life_leveling/pages/home/home_page.dart';
 import 'package:life_leveling/services/quest_service.dart';
-
-
+import 'package:life_leveling/services/theme_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await QuestService().init();
+  final themeMode = await ThemeService().getThemeMode();
 
-  runApp(const MyApp());
+  runApp(MyApp(initialThemeMode: themeMode));
 }
 
+class MyApp extends StatefulWidget {
+  final ThemeMode initialThemeMode;
+  const MyApp({super.key, required this.initialThemeMode});
 
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
 
+class _MyAppState extends State<MyApp> {
+  late ThemeMode _themeMode;
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  @override
+  void initState() {
+    super.initState();
+    _themeMode = widget.initialThemeMode;
+  }
+
+  void _updateTheme(ThemeMode mode) {
+    setState(() => _themeMode = mode);
+    ThemeService().saveThemeMode(mode);
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      // Rimuove il banner "debug" nell'angolo
       debugShowCheckedModeBanner: false,
-
-
-      // theme: SoloLevelingTheme.lightTheme,
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
+      themeMode: _themeMode,
+      home: MyHomePage(
+        currentThemeMode: _themeMode,
+        onThemeChanged: _updateTheme,
       ),
-
-      home: const MyHomePage(),
-
     );
   }
 }

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -3,11 +3,19 @@ import 'package:life_leveling/widgets/custom_bottom_navigation_bar.dart';
 import 'package:life_leveling/pages/dashboard/dashboard_page.dart';
 
 import 'package:life_leveling/pages/quests/quests_page.dart';
+import 'package:life_leveling/pages/settings/settings_page.dart';
 // import 'package:tuo_progetto/pages/progetti/progetti_page.dart';
 // import 'package:tuo_progetto/pages/grafici/grafici_page.dart';
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key}) : super(key: key);
+  final ThemeMode currentThemeMode;
+  final ValueChanged<ThemeMode> onThemeChanged;
+
+  const MyHomePage({
+    Key? key,
+    required this.currentThemeMode,
+    required this.onThemeChanged,
+  }) : super(key: key);
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
@@ -49,13 +57,15 @@ class _MyHomePageState extends State<MyHomePage> {
           IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {
-              // Se hai definito la SettingsPage come route, naviga così:
-              // Navigator.pushNamed(context, '/settings');
-              // Altrimenti, naviga a un widget inline:
-              // Navigator.push(
-              //   context,
-              //   MaterialPageRoute(builder: (context) => const SettingsPage()),
-              // );
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => SettingsPage(
+                    currentThemeMode: widget.currentThemeMode,
+                    onThemeChanged: widget.onThemeChanged,
+                  ),
+                ),
+              );
             },
           ),
         ],

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  final ThemeMode currentThemeMode;
+  final ValueChanged<ThemeMode> onThemeChanged;
+
+  const SettingsPage({
+    Key? key,
+    required this.currentThemeMode,
+    required this.onThemeChanged,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: const Text('Options'),
+      ),
+      body: Column(
+        children: [
+          RadioListTile<ThemeMode>(
+            title: const Text('Light Theme'),
+            value: ThemeMode.light,
+            groupValue: currentThemeMode,
+            onChanged: (ThemeMode? value) {
+              if (value != null) {
+                onThemeChanged(value);
+                Navigator.of(context).pop();
+              }
+            },
+          ),
+          RadioListTile<ThemeMode>(
+            title: const Text('Dark Theme'),
+            value: ThemeMode.dark,
+            groupValue: currentThemeMode,
+            onChanged: (ThemeMode? value) {
+              if (value != null) {
+                onThemeChanged(value);
+                Navigator.of(context).pop();
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeService {
+  static final ThemeService _instance = ThemeService._internal();
+  factory ThemeService() => _instance;
+  ThemeService._internal();
+
+  static const String _prefsKey = 'theme_mode';
+
+  Future<ThemeMode> getThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final int? value = prefs.getInt(_prefsKey);
+    if (value == 1) {
+      return ThemeMode.dark;
+    }
+    return ThemeMode.light;
+  }
+
+  Future<void> saveThemeMode(ThemeMode mode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_prefsKey, mode == ThemeMode.dark ? 1 : 0);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ThemeService` to save preference
- add `SettingsPage` with light/dark selection
- wire settings icon in `HomePage` to open the options page
- make `MyApp` stateful to handle theme changes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e87ff538832c8682a7ffe8209338