### PR TITLE
Add daily fatigue tracking

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:life_leveling/pages/home/home_page.dart';
 import 'package:life_leveling/services/quest_service.dart';
 import 'package:life_leveling/services/theme_service.dart';
+import 'package:life_leveling/services/fatigue_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await QuestService().init();
+  await FatigueService().init();
   final themeMode = await ThemeService().getThemeMode();
 
   runApp(MyApp(initialThemeMode: themeMode));

--- a/lib/pages/dashboard/dashboard_page.dart
+++ b/lib/pages/dashboard/dashboard_page.dart
@@ -5,6 +5,7 @@ import 'package:life_leveling/services/quest_service.dart';
 import 'package:life_leveling/pages/dashboard/livello_dettagli_page.dart';
 import 'package:life_leveling/pages/quests/quest_detail_page.dart';
 import 'package:intl/intl.dart';
+import 'package:life_leveling/services/fatigue_service.dart';
 
 class DashboardPage extends StatefulWidget {
   const DashboardPage({Key? key}) : super(key: key);
@@ -70,6 +71,7 @@ class _DashboardPageState extends State<DashboardPage> {
                 requiredXP: requiredXP,
                 userClass: userClass,
                 userAbilities: userAbilities,
+                dailyFatigue: FatigueService().fatigue,
               ),
             ),
             const SizedBox(height: 24.0),
@@ -171,6 +173,7 @@ class _DashboardPageState extends State<DashboardPage> {
     required double requiredXP,
     required String userClass,
     required String userAbilities,
+    required int dailyFatigue,
   }) {
     final double xpPercentage = (currentXP / requiredXP).clamp(0.0, 1.0);
 
@@ -187,6 +190,7 @@ class _DashboardPageState extends State<DashboardPage> {
               requiredXP: requiredXP,
               userClass: userClass,
               userAbilities: userAbilities,
+              dailyFatigue: dailyFatigue,
             ),
           ),
         );
@@ -238,6 +242,17 @@ class _DashboardPageState extends State<DashboardPage> {
           Text(
             'Abilità: $userAbilities',
             style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 4.0),
+          Text(
+            'Fatica odierna: $dailyFatigue/100',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: dailyFatigue > 100
+                      ? Colors.red
+                      : dailyFatigue > 50
+                          ? Colors.orange
+                          : Colors.black,
+                ),
           ),
         ],
       ),

--- a/lib/pages/dashboard/livello_dettagli_page.dart
+++ b/lib/pages/dashboard/livello_dettagli_page.dart
@@ -12,6 +12,7 @@ class LivelloDettagliPage extends StatelessWidget {
   final double requiredXP;
   final String userClass;
   final String userAbilities;
+  final int dailyFatigue;
 
   const LivelloDettagliPage({
     Key? key,
@@ -21,6 +22,7 @@ class LivelloDettagliPage extends StatelessWidget {
     required this.requiredXP,
     required this.userClass,
     required this.userAbilities,
+    required this.dailyFatigue,
   }) : super(key: key);
 
   @override
@@ -68,6 +70,17 @@ class LivelloDettagliPage extends StatelessWidget {
             Text(
               'Abilità: $userAbilities',
               style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 4.0),
+            Text(
+              'Fatica odierna: $dailyFatigue/100',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: dailyFatigue > 100
+                        ? Colors.red
+                        : dailyFatigue > 50
+                            ? Colors.orange
+                            : Colors.black,
+                  ),
             ),
 
             // Spazio per ulteriori dettagli

--- a/lib/pages/quests/quest_detail_page.dart
+++ b/lib/pages/quests/quest_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:life_leveling/models/quest_model.dart';
 import 'package:life_leveling/services/quest_service.dart';
+import 'package:life_leveling/services/fatigue_service.dart';
 import 'package:intl/intl.dart';
 
 class QuestDetailsPage extends StatelessWidget {
@@ -13,6 +14,14 @@ class QuestDetailsPage extends StatelessWidget {
       appBar: AppBar(
         title: Text(quest.title),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.check),
+            onPressed: () async {
+              await FatigueService().addFatigue(quest.fatigue);
+              await QuestService().removeQuest(quest);
+              Navigator.of(context).pop(true);
+            },
+          ),
           IconButton(
             icon: const Icon(Icons.delete),
             onPressed: () async {

--- a/lib/services/fatigue_service.dart
+++ b/lib/services/fatigue_service.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FatigueService {
+  static final FatigueService _instance = FatigueService._internal();
+  factory FatigueService() => _instance;
+  FatigueService._internal();
+
+  static const String _prefsKey = 'daily_fatigue';
+
+  int _fatigue = 0;
+  DateTime _date = DateTime.now();
+
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_prefsKey);
+    if (jsonString != null) {
+      final data = json.decode(jsonString);
+      _fatigue = data['value'] ?? 0;
+      _date = DateTime.tryParse(data['date'] ?? '') ?? DateTime.now();
+    }
+    _resetIfNeeded();
+    await _save();
+  }
+
+  int get fatigue {
+    _resetIfNeeded();
+    return _fatigue;
+  }
+
+  Future<void> addFatigue(int value) async {
+    _resetIfNeeded();
+    _fatigue += value;
+    await _save();
+  }
+
+  void _resetIfNeeded() {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    if (_date.year != today.year || _date.month != today.month || _date.day != today.day) {
+      _date = today;
+      _fatigue = 0;
+    }
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = json.encode({'date': _date.toIso8601String(), 'value': _fatigue});
+    await prefs.setString(_prefsKey, data);
+  }
+}


### PR DESCRIPTION
## Summary
- add `FatigueService` for tracking daily fatigue
- initialize fatigue service on app startup
- display current daily fatigue on the dashboard header and on the profile page
- allow marking a quest as complete which increases fatigue

## Testing
- `flutter` command not available


------
https://chatgpt.com/codex/tasks/task_e_6877ec699e90832c9ca00c4471e4ba75