### PR TITLE
Implement level system with class examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Classes
+
+You can define your own character classes inside `lib/classes`. The
+`example_classes.dart` file provides some sample classes that the app uses by
+default. Add your classes to this folder to extend the level progression.

--- a/lib/classes/example_classes.dart
+++ b/lib/classes/example_classes.dart
@@ -1,0 +1,19 @@
+import '../models/class_model.dart';
+
+const List<LevelClass> exampleClasses = [
+  LevelClass(
+    name: 'Apprendista',
+    abilities: ['Vivere'],
+    requiredLevel: 1,
+  ),
+  LevelClass(
+    name: 'Avventuriero',
+    abilities: ['Vivere', 'Combattere'],
+    requiredLevel: 5,
+  ),
+  LevelClass(
+    name: 'Cacciatore',
+    abilities: ['Vivere', 'Combattere', 'Strategia'],
+    requiredLevel: 10,
+  ),
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,12 +3,14 @@ import 'package:life_leveling/pages/home/home_page.dart';
 import 'package:life_leveling/services/quest_service.dart';
 import 'package:life_leveling/services/theme_service.dart';
 import 'package:life_leveling/services/fatigue_service.dart';
+import 'package:life_leveling/services/level_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   await QuestService().init();
   await FatigueService().init();
+  await LevelService().init();
   final themeMode = await ThemeService().getThemeMode();
 
   runApp(MyApp(initialThemeMode: themeMode));

--- a/lib/models/class_model.dart
+++ b/lib/models/class_model.dart
@@ -1,0 +1,11 @@
+class LevelClass {
+  final String name;
+  final List<String> abilities;
+  final int requiredLevel;
+
+  const LevelClass({
+    required this.name,
+    required this.abilities,
+    required this.requiredLevel,
+  });
+}

--- a/lib/pages/dashboard/dashboard_page.dart
+++ b/lib/pages/dashboard/dashboard_page.dart
@@ -6,6 +6,7 @@ import 'package:life_leveling/pages/dashboard/livello_dettagli_page.dart';
 import 'package:life_leveling/pages/quests/quest_detail_page.dart';
 import 'package:intl/intl.dart';
 import 'package:life_leveling/services/fatigue_service.dart';
+import 'package:life_leveling/services/level_service.dart';
 
 class DashboardPage extends StatefulWidget {
   const DashboardPage({Key? key}) : super(key: key);
@@ -15,13 +16,8 @@ class DashboardPage extends StatefulWidget {
 }
 
 class _DashboardPageState extends State<DashboardPage> {
-  // Dati utente (esempio)
+  // Dati utente
   final String userName = 'Corrado Enea Crevatin';
-  final int currentLevel = 1;
-  final double currentXP = 0;
-  final double requiredXP = 10.0;
-  final String userClass = 'Principiante';
-  final String userAbilities = 'Vivere';
 
   bool _isOverdue(QuestData quest) {
     final now = DateTime.now();
@@ -54,6 +50,13 @@ class _DashboardPageState extends State<DashboardPage> {
     final top3Daily = dailyQuests.length > 3
         ? dailyQuests.sublist(0, 3)
         : dailyQuests;
+
+    final levelService = LevelService();
+    final currentLevel = levelService.level;
+    final currentXP = levelService.xp;
+    final requiredXP = levelService.requiredXp;
+    final userClass = levelService.currentClass.name;
+    final userAbilities = levelService.currentClass.abilities.join(', ');
 
     return SingleChildScrollView(
       child: Padding(
@@ -251,7 +254,7 @@ class _DashboardPageState extends State<DashboardPage> {
                       ? Colors.red
                       : dailyFatigue > 50
                           ? Colors.orange
-                          : Colors.black,
+                          : (Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black),
                 ),
           ),
         ],

--- a/lib/pages/dashboard/livello_dettagli_page.dart
+++ b/lib/pages/dashboard/livello_dettagli_page.dart
@@ -79,7 +79,7 @@ class LivelloDettagliPage extends StatelessWidget {
                         ? Colors.red
                         : dailyFatigue > 50
                             ? Colors.orange
-                            : Colors.black,
+                            : (Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black),
                   ),
             ),
 

--- a/lib/pages/quests/quest_detail_page.dart
+++ b/lib/pages/quests/quest_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:life_leveling/models/quest_model.dart';
 import 'package:life_leveling/services/quest_service.dart';
 import 'package:life_leveling/services/fatigue_service.dart';
+import 'package:life_leveling/services/level_service.dart';
 import 'package:intl/intl.dart';
 
 class QuestDetailsPage extends StatelessWidget {
@@ -18,6 +19,7 @@ class QuestDetailsPage extends StatelessWidget {
             icon: const Icon(Icons.check),
             onPressed: () async {
               await FatigueService().addFatigue(quest.fatigue);
+              await LevelService().addXp(quest.xp.toDouble());
               await QuestService().removeQuest(quest);
               Navigator.of(context).pop(true);
             },

--- a/lib/services/level_service.dart
+++ b/lib/services/level_service.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:life_leveling/models/class_model.dart';
+import 'package:life_leveling/classes/example_classes.dart';
+
+class LevelService {
+  static final LevelService _instance = LevelService._internal();
+  factory LevelService() => _instance;
+  LevelService._internal();
+
+  static const String _prefsKey = 'level_data';
+
+  int _level = 1;
+  double _xp = 0;
+  int _classIndex = 0;
+
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_prefsKey);
+    if (jsonString != null) {
+      final data = json.decode(jsonString);
+      _level = data['level'] ?? 1;
+      _xp = (data['xp'] ?? 0).toDouble();
+      _classIndex = data['classIndex'] ?? 0;
+    }
+  }
+
+  int get level => _level;
+  double get xp => _xp;
+  LevelClass get currentClass => exampleClasses[_classIndex];
+  double get requiredXp => _requiredXpForLevel(_level);
+
+  Future<void> addXp(double amount) async {
+    _xp += amount;
+    while (_xp >= requiredXp) {
+      _xp -= requiredXp;
+      _level++;
+      _checkClassUpgrade();
+    }
+    await _save();
+  }
+
+  double _requiredXpForLevel(int lvl) {
+    const double baseXp = 100;
+    const double growth = 1.5;
+    return baseXp * pow(growth, lvl - 1);
+  }
+
+  void _checkClassUpgrade() {
+    if (_classIndex + 1 < exampleClasses.length) {
+      final nextClass = exampleClasses[_classIndex + 1];
+      if (_level >= nextClass.requiredLevel) {
+        _classIndex++;
+      }
+    }
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = json.encode({
+      'level': _level,
+      'xp': _xp,
+      'classIndex': _classIndex,
+    });
+    await prefs.setString(_prefsKey, data);
+  }
+}


### PR DESCRIPTION
## Summary
- add `LevelService` to manage XP, levels and classes
- store example classes in `lib/classes/example_classes.dart`
- update dashboard and quest pages to use `LevelService`
- change fatigue text color in dark mode
- document how to extend classes in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ef1572b0832cab4665803d6d25e5