### PR TITLE
Add daily stats tracking and navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:life_leveling/services/quest_service.dart';
 import 'package:life_leveling/services/theme_service.dart';
 import 'package:life_leveling/services/fatigue_service.dart';
 import 'package:life_leveling/services/level_service.dart';
+import 'package:life_leveling/services/stats_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -11,6 +12,7 @@ void main() async {
   await QuestService().init();
   await FatigueService().init();
   await LevelService().init();
+  await StatsService().init();
   final themeMode = await ThemeService().getThemeMode();
 
   runApp(MyApp(initialThemeMode: themeMode));

--- a/lib/pages/dashboard/dashboard_page.dart
+++ b/lib/pages/dashboard/dashboard_page.dart
@@ -7,6 +7,7 @@ import 'package:life_leveling/pages/quests/quest_detail_page.dart';
 import 'package:intl/intl.dart';
 import 'package:life_leveling/services/fatigue_service.dart';
 import 'package:life_leveling/services/level_service.dart';
+import 'package:life_leveling/services/stats_service.dart';
 
 class DashboardPage extends StatefulWidget {
   const DashboardPage({Key? key}) : super(key: key);
@@ -18,6 +19,7 @@ class DashboardPage extends StatefulWidget {
 class _DashboardPageState extends State<DashboardPage> {
   // Dati utente
   final String userName = 'Corrado Enea Crevatin';
+  DateTime _statsDate = DateTime.now();
 
   bool _isOverdue(QuestData quest) {
     final now = DateTime.now();
@@ -77,6 +79,9 @@ class _DashboardPageState extends State<DashboardPage> {
                 dailyFatigue: FatigueService().fatigue,
               ),
             ),
+            const SizedBox(height: 24.0),
+
+            _buildStatsCard(context),
             const SizedBox(height: 24.0),
 
             // --- Box Quest ad Alta Priorità ---
@@ -155,14 +160,62 @@ class _DashboardPageState extends State<DashboardPage> {
   }) {
     return Card(
       elevation: 4.0,
-      clipBehavior: Clip
-          .antiAlias, // consente di avere la ripple effect su tutto il card se cliccato
+      clipBehavior: Clip.antiAlias, // consente di avere la ripple effect su tutto il card se cliccato
       child: InkWell(
         onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.all(16.0),
           child: child,
         ),
+      ),
+    );
+  }
+
+  Widget _buildStatsCard(BuildContext context) {
+    final stats = StatsService().getStats(_statsDate);
+    return _buildDashboardCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () {
+                  setState(() {
+                    _statsDate = _statsDate.subtract(const Duration(days: 1));
+                  });
+                },
+              ),
+              Text(
+                DateFormat('dd/MM/yyyy').format(_statsDate),
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+              IconButton(
+                icon: const Icon(Icons.arrow_forward),
+                onPressed: () {
+                  setState(() {
+                    _statsDate = _statsDate.add(const Duration(days: 1));
+                  });
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Quest completate: ${stats.questsCompleted}',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          Text(
+            'XP guadagnati: ${stats.xpGained.toInt()}',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          Text(
+            'Fatica: ${stats.fatigue}',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/quests/quest_detail_page.dart
+++ b/lib/pages/quests/quest_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:life_leveling/models/quest_model.dart';
 import 'package:life_leveling/services/quest_service.dart';
 import 'package:life_leveling/services/fatigue_service.dart';
 import 'package:life_leveling/services/level_service.dart';
+import 'package:life_leveling/services/stats_service.dart';
 import 'package:intl/intl.dart';
 
 class QuestDetailsPage extends StatelessWidget {
@@ -20,6 +21,8 @@ class QuestDetailsPage extends StatelessWidget {
             onPressed: () async {
               await FatigueService().addFatigue(quest.fatigue);
               await LevelService().addXp(quest.xp.toDouble());
+              await StatsService()
+                  .recordQuestCompleted(xp: quest.xp.toDouble(), fatigue: quest.fatigue);
               await QuestService().removeQuest(quest);
               Navigator.of(context).pop(true);
             },

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DailyStats {
+  final DateTime date;
+  int questsCompleted;
+  double xpGained;
+  int fatigue;
+
+  DailyStats({
+    required this.date,
+    this.questsCompleted = 0,
+    this.xpGained = 0,
+    this.fatigue = 0,
+  });
+
+  factory DailyStats.fromJson(Map<String, dynamic> json) {
+    return DailyStats(
+      date: DateTime.parse(json['date'] as String),
+      questsCompleted: json['questsCompleted'] ?? 0,
+      xpGained: (json['xpGained'] ?? 0).toDouble(),
+      fatigue: json['fatigue'] ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'date': date.toIso8601String(),
+      'questsCompleted': questsCompleted,
+      'xpGained': xpGained,
+      'fatigue': fatigue,
+    };
+  }
+}
+
+class StatsService {
+  static final StatsService _instance = StatsService._internal();
+  factory StatsService() => _instance;
+  StatsService._internal();
+
+  static const String _prefsKey = 'daily_stats';
+
+  final Map<String, DailyStats> _stats = {};
+
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_prefsKey);
+    if (jsonString != null && jsonString.isNotEmpty) {
+      final List decoded = json.decode(jsonString);
+      _stats.clear();
+      for (var item in decoded) {
+        final stat = DailyStats.fromJson(item);
+        _stats[_dateKey(stat.date)] = stat;
+      }
+    }
+  }
+
+  String _dateKey(DateTime date) {
+    final d = DateTime(date.year, date.month, date.day);
+    return d.toIso8601String();
+  }
+
+  DailyStats _getStatsFor(DateTime date) {
+    final key = _dateKey(date);
+    if (!_stats.containsKey(key)) {
+      _stats[key] = DailyStats(date: DateTime(date.year, date.month, date.day));
+    }
+    return _stats[key]!;
+  }
+
+  DailyStats getStats(DateTime date) {
+    final key = _dateKey(date);
+    return _stats[key] ?? DailyStats(date: DateTime(date.year, date.month, date.day));
+  }
+
+  Future<void> recordQuestCompleted({required double xp, required int fatigue}) async {
+    final now = DateTime.now();
+    final stat = _getStatsFor(now);
+    stat.questsCompleted += 1;
+    stat.xpGained += xp;
+    stat.fatigue += fatigue;
+    await _save();
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = _stats.values.map((s) => s.toJson()).toList();
+    await prefs.setString(_prefsKey, json.encode(data));
+  }
+}


### PR DESCRIPTION
## Summary
- track daily stats with `StatsService`
- record quest completions in `QuestDetailsPage`
- initialise `StatsService` in `main.dart`
- show daily stats on the dashboard and allow browsing past days

## Testing
- `flutter pub get` *(fails: `flutter` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f1d708d8832cb7e8aa8369e6c781