### PR TITLE
Add blank default task status

### DIFF
--- a/lib/pages/progetti/progetti_page.dart
+++ b/lib/pages/progetti/progetti_page.dart
@@ -3,6 +3,7 @@ import 'package:life_leveling/models/project_models.dart';
 import 'package:intl/intl.dart';
 
 const List<String> kTaskStatusOptions = [
+  '',
   'Done',
   'Working on it',
   'Stuck',
@@ -412,6 +413,8 @@ class _ProgettiPageState extends State<ProgettiPage> {
 
   Color _statusColor(String status) {
     switch (status) {
+      case '':
+        return Colors.grey;
       case 'Stuck':
         return Colors.red;
       case 'Done':


### PR DESCRIPTION
## Summary
- add an empty status at the start of `kTaskStatusOptions`
- return grey color for the blank status so its chip appears gray

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878096111d8832cb909ea74535a5ddc