### PR TITLE
Add extra group colors and adjust status chip

### DIFF
--- a/lib/pages/progetti/progetti_page.dart
+++ b/lib/pages/progetti/progetti_page.dart
@@ -35,6 +35,7 @@ class _ProgettiPageState extends State<ProgettiPage> {
   Widget _statusChip(String status) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      margin: const EdgeInsets.only(right: 4),
       decoration: BoxDecoration(
         color: _statusColor(status),
         borderRadius: BorderRadius.circular(4),
@@ -327,6 +328,10 @@ class _ProgettiPageState extends State<ProgettiPage> {
       'Blue': Colors.blue,
       'Green': Colors.green,
       'Red': Colors.red,
+      'Orange': Colors.orange,
+      'Purple': Colors.purple,
+      'Pink': Colors.pink,
+      'Teal': Colors.teal,
     };
     await showDialog(
       context: context,


### PR DESCRIPTION
## Summary
- allow more color choices when creating a group
- add a right margin to the status chip so it isn't too close to the next column

## Testing
- `flutter test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68780f40af3c832c8293f8969c48e548