### PR TITLE
Add xp & fatigue to project tasks

### DIFF
--- a/lib/models/project_models.dart
+++ b/lib/models/project_models.dart
@@ -54,11 +54,15 @@ class BoardGroup {
 
 class BoardItem {
   final String title;
+  final int xp;
+  final int fatigue;
   final List<String> values;
   final List<BoardItem> subItems;
 
   BoardItem({
     required this.title,
+    this.xp = 0,
+    this.fatigue = 0,
     List<String>? values,
     List<BoardItem>? subItems,
   })  : values = List<String>.from(values ?? <String>[]),

--- a/lib/pages/progetti/progetti_page.dart
+++ b/lib/pages/progetti/progetti_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:life_leveling/models/project_models.dart';
 import 'package:intl/intl.dart';
+import 'package:life_leveling/models/quest_model.dart';
+import 'package:life_leveling/services/quest_service.dart';
 
 const List<String> kTaskStatusOptions = [
   '',
@@ -399,6 +401,8 @@ class _ProgettiPageState extends State<ProgettiPage> {
     final titleController = TextEditingController();
     String selectedStatus = kTaskStatusOptions.first;
     final dueController = TextEditingController();
+    final xpController = TextEditingController();
+    int fatigue = 0;
     await showDialog(
       context: context,
       builder: (_) => StatefulBuilder(
@@ -442,6 +446,21 @@ class _ProgettiPageState extends State<ProgettiPage> {
                   }
                 },
               ),
+              TextField(
+                controller: xpController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: 'XP'),
+              ),
+              const SizedBox(height: 8),
+              Text('Fatigue: $fatigue'),
+              Slider(
+                value: fatigue.toDouble(),
+                min: 0,
+                max: 100,
+                divisions: 100,
+                label: '$fatigue',
+                onChanged: (v) => setModalState(() => fatigue = v.round()),
+              ),
             ],
           ),
           actions: [
@@ -450,13 +469,28 @@ class _ProgettiPageState extends State<ProgettiPage> {
               child: const Text('Cancel'),
             ),
             TextButton(
-              onPressed: () {
+              onPressed: () async {
+                final xp = int.tryParse(xpController.text) ?? 0;
                 setState(() {
                   group.items.add(BoardItem(
                     title: titleController.text,
+                    xp: xp,
+                    fatigue: fatigue,
                     values: [selectedStatus, dueController.text],
                   ));
                 });
+                await QuestService().addQuest(
+                  QuestData(
+                    title: titleController.text,
+                    deadline: dueController.text.isNotEmpty
+                        ? DateTime.parse(dueController.text)
+                        : DateTime.now(),
+                    isDaily: false,
+                    xp: xp,
+                    notes: '',
+                    fatigue: fatigue,
+                  ),
+                );
                 Navigator.pop(context);
               },
               child: const Text('Add'),
@@ -471,6 +505,8 @@ class _ProgettiPageState extends State<ProgettiPage> {
     final titleController = TextEditingController();
     String selectedStatus = kTaskStatusOptions.first;
     final dueController = TextEditingController();
+    final xpController = TextEditingController();
+    int fatigue = 0;
     await showDialog(
       context: context,
       builder: (_) => StatefulBuilder(
@@ -515,6 +551,21 @@ class _ProgettiPageState extends State<ProgettiPage> {
                   }
                 },
               ),
+              TextField(
+                controller: xpController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: 'XP'),
+              ),
+              const SizedBox(height: 8),
+              Text('Fatigue: $fatigue'),
+              Slider(
+                value: fatigue.toDouble(),
+                min: 0,
+                max: 100,
+                divisions: 100,
+                label: '$fatigue',
+                onChanged: (v) => setModalState(() => fatigue = v.round()),
+              ),
             ],
           ),
           actions: [
@@ -523,15 +574,30 @@ class _ProgettiPageState extends State<ProgettiPage> {
               child: const Text('Cancel'),
             ),
             TextButton(
-              onPressed: () {
+              onPressed: () async {
+                final xp = int.tryParse(xpController.text) ?? 0;
                 setState(() {
                   parent.subItems.add(
                     BoardItem(
                       title: titleController.text,
+                      xp: xp,
+                      fatigue: fatigue,
                       values: [selectedStatus, dueController.text],
                     ),
                   );
                 });
+                await QuestService().addQuest(
+                  QuestData(
+                    title: titleController.text,
+                    deadline: dueController.text.isNotEmpty
+                        ? DateTime.parse(dueController.text)
+                        : DateTime.now(),
+                    isDaily: false,
+                    xp: xp,
+                    notes: '',
+                    fatigue: fatigue,
+                  ),
+                );
                 Navigator.pop(context);
               },
               child: const Text('Add'),
@@ -568,16 +634,22 @@ class _ProgettiPageState extends State<ProgettiPage> {
           items: [
             BoardItem(
               title: 'Task 1',
+              xp: 10,
+              fatigue: 5,
               values: ['Working on it', '2023-12-01'],
               subItems: [
                 BoardItem(
                   title: 'Subtask 1',
+                  xp: 5,
+                  fatigue: 3,
                   values: ['Done', ''],
                 ),
               ],
             ),
             BoardItem(
               title: 'Task 2',
+              xp: 15,
+              fatigue: 7,
               values: ['Stuck', '2023-11-15'],
             ),
           ],
@@ -588,6 +660,8 @@ class _ProgettiPageState extends State<ProgettiPage> {
           items: [
             BoardItem(
               title: 'Task 3',
+              xp: 20,
+              fatigue: 10,
               values: ['Done', '2023-10-01'],
             ),
           ],


### PR DESCRIPTION
## Summary
- include xp and fatigue fields in `BoardItem`
- allow entering xp and fatigue when creating tasks and subtasks
- create a corresponding quest whenever a task/subtask is created
- provide sample data with xp and fatigue
- fix missing variable declarations in task dialog and repair subtask dialog button

## Testing
- `dart format -o none -l 120 lib/pages/progetti/progetti_page.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6878112b9090832cbb8c3eb38ab5699c