### PR TITLE
Enable quest details from project tasks

### DIFF
--- a/lib/models/project_models.dart
+++ b/lib/models/project_models.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'quest_model.dart';
 
 class Workspace {
   final String name;
@@ -58,11 +59,13 @@ class BoardItem {
   final int fatigue;
   final List<String> values;
   final List<BoardItem> subItems;
+  final QuestData? quest;
 
   BoardItem({
     required this.title,
     this.xp = 0,
     this.fatigue = 0,
+    this.quest,
     List<String>? values,
     List<BoardItem>? subItems,
   })  : values = List<String>.from(values ?? <String>[]),


### PR DESCRIPTION
## Summary
- link tasks in `progetti` to their quest objects
- allow tapping a task row to open `QuestDetailsPage`
- compute DataTable width based on screen size for better responsiveness

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878150c6c1c832cbf50e699aaa7ca21